### PR TITLE
build_eml_file(): making date less ambiguous

### DIFF
--- a/easymail
+++ b/easymail
@@ -112,7 +112,7 @@ Content-Type: multipart/mixed; boundary=\"----7II5XTH4IPXG2QZOY8LJF98QQX4IR3\"
 Content-Transfer-Encoding: 8bit
 Subject: $subject
 From: Easymail <easymail@unixrules.nix>
-Date: $(date)
+Date: $(date -R)
 To: $header_destination
 
 ------7II5XTH4IPXG2QZOY8LJF98QQX4IR3


### PR DESCRIPTION
User can use non-standard symbolic name of his timezone